### PR TITLE
Add holdings example for mock trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ export kiwoom_appkey=발급받은_앱키
 export kiwoom_secretkey=발급받은_비밀키
 ```
 
+모의투자 환경을 사용하려면 `KiwoomClient` 생성 시 `is_mock=True` 옵션을 지정합니다.
+또한 보유종목 조회 예제를 실행하려면 계좌번호(`kiwoom_cano`)와 계좌상품코드(`kiwoom_acnt_prdt_cd`)도 환경 변수로 설정해야 합니다.
+
 ### 인증 및 시세 조회 예제
 
 ```python

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@
    - 거래정지종목, 관리종목 조회
    - 종목 검색 및 재무정보 조회
    - 투자자 동향 조회
+3. **holdings_example.py**: 모의투자 계좌의 보유종목을 조회하는 예제
 
 ## 사용 방법
 
@@ -26,6 +27,8 @@
    # macOS/Linux
    export kiwoom_appkey=발급받은_앱키
    export kiwoom_secretkey=발급받은_비밀키
+   export kiwoom_cano=계좌번호8자리
+   export kiwoom_acnt_prdt_cd=계좌상품코드2자리
    ```
 
 2. 필요 패키지 설치
@@ -40,6 +43,9 @@
    
    # 종목 정보 조회 예제
    python stock_info_example.py
+
+   # 보유종목 조회 예제
+   python holdings_example.py
    ```
 
 ## 주의사항

--- a/examples/holdings_example.py
+++ b/examples/holdings_example.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Example script to check holdings in a Kiwoom mock account."""
+
+import os
+import json
+from kiwoom_api import KiwoomClient
+
+
+def main():
+    """Fetch and print account holdings using the mock trading environment."""
+    appkey = os.environ.get("kiwoom_appkey")
+    secretkey = os.environ.get("kiwoom_secretkey")
+    cano = os.environ.get("kiwoom_cano")
+    acnt_prdt_cd = os.environ.get("kiwoom_acnt_prdt_cd")
+
+    if not all([appkey, secretkey, cano, acnt_prdt_cd]):
+        print("환경 변수에 API 키와 계좌 정보를 설정해주세요.")
+        print("필요 변수: kiwoom_appkey, kiwoom_secretkey, kiwoom_cano, kiwoom_acnt_prdt_cd")
+        return
+
+    client = KiwoomClient(appkey, secretkey, is_mock=True)
+
+    response = client.account.get_account_balance(
+        cano=cano,
+        acnt_prdt_cd=acnt_prdt_cd,
+    )
+
+    print(json.dumps(response, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `examples/holdings_example.py` to print account holdings using `KiwoomClient` in mock mode
- document new example and required environment variables in examples README
- mention paper trading environment setup in project README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c879bce48322a27581fcb357e581